### PR TITLE
Fix recompute lines with tuple

### DIFF
--- a/account_voucher_supplier_invoice_number/models/account_voucher.py
+++ b/account_voucher_supplier_invoice_number/models/account_voucher.py
@@ -25,11 +25,11 @@ class AccountVoucher(models.Model):
 
         if res.get('value') and res['value'].get('line_cr_ids'):
             for vals in res['value']['line_cr_ids']:
-                if vals.get('move_line_id'):
+                if type(vals) == dict and vals.get('move_line_id'):
                     update_move_line(vals)
 
         if res.get('value') and res['value'].get('line_dr_ids'):
             for vals in res['value']['line_dr_ids']:
-                if vals.get('move_line_id'):
+                if type(vals) == dict and vals.get('move_line_id'):
                     update_move_line(vals)
         return res


### PR DESCRIPTION
account_voucher_supplier_invoice_number: recompute_voucher_lines()
sometimes returns a tuple instead of a dict in line_cr_ids or
line_dr_ids